### PR TITLE
Feature consistent filename outputs

### DIFF
--- a/R/RWR_CV.R
+++ b/R/RWR_CV.R
@@ -787,7 +787,7 @@ RWR_CV <- function(
         # )
         out_path = get_file_path(
             "RWR-CV",
-            slug="fullranks"
+            slug="fullranks",
             modname=modname,
             outdir=outdirPath
         )
@@ -810,7 +810,7 @@ RWR_CV <- function(
         #                          outdir=outdirPath, ext=".medianranks.tsv")
         out_path = get_file_path(
             "RWR-CV",
-            slug="medianranks"
+            slug="medianranks",
             modname=modname,
             outdir=outdirPath
         )
@@ -828,7 +828,7 @@ RWR_CV <- function(
     #                          outdir=outdirPath, ext=".metrics.tsv")
     out_path = get_file_path(
         "RWR-CV",
-        slug="metrics"
+        slug="metrics",
         modname=modname,
         outdir=outdirPath
     )
@@ -838,7 +838,7 @@ RWR_CV <- function(
     #                          outdir=outdirPath, ext=".summary.tsv")
     out_path = get_file_path(
         "RWR-CV",
-        slug="summary"
+        slug="summary",
         modname=modname,
         outdir=outdirPath
     )

--- a/R/RWR_CV.R
+++ b/R/RWR_CV.R
@@ -777,14 +777,6 @@ RWR_CV <- function(
     if (!is.null(outFullRanks)) {
         out_path = outFullRanks
     } else {
-        # out_path = get_file_path(
-        #     "RWR-CV_",
-        #     res_combined$geneset[1],
-        #     basename(dataPath),
-        #     modname,
-        #     outdir=outdirPath,
-        #     ext=".fullranks.tsv"
-        # )
         out_path = get_file_path(
             "RWR-CV",
             slug="fullranks",
@@ -806,8 +798,6 @@ RWR_CV <- function(
     if (!is.null(outMedianRanks)) {
         out_path = outMedianRanks
     } else {
-        # out_path = get_file_path("RWR-CV_",res_avg$geneset[1],basename(dataPath),modname,
-        #                          outdir=outdirPath, ext=".medianranks.tsv")
         out_path = get_file_path(
             "RWR-CV",
             slug="medianranks",
@@ -823,26 +813,22 @@ RWR_CV <- function(
     }
 
     ############# Save metrics  ################################################
-
-    # out_path = get_file_path("RWR-CV_", metrics$res_combined$geneset[1], basename(dataPath),modname,
-    #                          outdir=outdirPath, ext=".metrics.tsv")
     out_path = get_file_path(
         "RWR-CV",
         slug="metrics",
         modname=modname,
         outdir=outdirPath
     )
-    if(write_to_file){write_table(metrics$res_avg, out_path)}
+    if (write_to_file) { write_table(metrics$res_avg, out_path) }
 
-    # out_path = get_file_path("RWR-CV_", metrics$res_combined$geneset[1], basename(dataPath), modname,
-    #                          outdir=outdirPath, ext=".summary.tsv")
+    ############# Save summary  ################################################
     out_path = get_file_path(
         "RWR-CV",
         slug="summary",
         modname=modname,
         outdir=outdirPath
     )
-    if(write_to_file){write_table(metrics$summary, out_path)}
+    if (write_to_file) { write_table(metrics$summary, out_path) }
 
     ############# Save plots  ##################################################
     if (plot) {

--- a/R/RWR_CV.R
+++ b/R/RWR_CV.R
@@ -777,11 +777,23 @@ RWR_CV <- function(
     if (!is.null(outFullRanks)) {
         out_path = outFullRanks
     } else {
-        out_path = get_file_path("RWR-CV_",res_combined$geneset[1],basename(dataPath),modname,
-                                 outdir=outdirPath, ext=".fullranks.tsv")
+        # out_path = get_file_path(
+        #     "RWR-CV_",
+        #     res_combined$geneset[1],
+        #     basename(dataPath),
+        #     modname,
+        #     outdir=outdirPath,
+        #     ext=".fullranks.tsv"
+        # )
+        out_path = get_file_path(
+            "RWR-CV",
+            slug="fullranks"
+            modname=modname,
+            outdir=outdirPath
+        )
     }
     
-    if(write_to_file){
+    if (write_to_file) {
         combined <- res_combined %>%
                         dplyr::group_by(fold) %>%
                         dplyr::slice_head(prop=numranked)
@@ -794,11 +806,17 @@ RWR_CV <- function(
     if (!is.null(outMedianRanks)) {
         out_path = outMedianRanks
     } else {
-        out_path = get_file_path("RWR-CV_",res_avg$geneset[1],basename(dataPath),modname,
-                                 outdir=outdirPath, ext=".medianranks.tsv")
+        # out_path = get_file_path("RWR-CV_",res_avg$geneset[1],basename(dataPath),modname,
+        #                          outdir=outdirPath, ext=".medianranks.tsv")
+        out_path = get_file_path(
+            "RWR-CV",
+            slug="medianranks"
+            modname=modname,
+            outdir=outdirPath
+        )
     }
 
-    if(write_to_file){
+    if (write_to_file) {
         write_table(res_avg %>%
                     dplyr::slice_head(prop=numranked),
                 out_path)
@@ -806,12 +824,24 @@ RWR_CV <- function(
 
     ############# Save metrics  ################################################
 
-    out_path = get_file_path("RWR-CV_", metrics$res_combined$geneset[1], basename(dataPath),modname,
-                             outdir=outdirPath, ext=".metrics.tsv")
+    # out_path = get_file_path("RWR-CV_", metrics$res_combined$geneset[1], basename(dataPath),modname,
+    #                          outdir=outdirPath, ext=".metrics.tsv")
+    out_path = get_file_path(
+        "RWR-CV",
+        slug="metrics"
+        modname=modname,
+        outdir=outdirPath
+    )
     if(write_to_file){write_table(metrics$res_avg, out_path)}
 
-    out_path = get_file_path("RWR-CV_", metrics$res_combined$geneset[1], basename(dataPath), modname,
-                             outdir=outdirPath, ext=".summary.tsv")
+    # out_path = get_file_path("RWR-CV_", metrics$res_combined$geneset[1], basename(dataPath), modname,
+    #                          outdir=outdirPath, ext=".summary.tsv")
+    out_path = get_file_path(
+        "RWR-CV",
+        slug="summary"
+        modname=modname,
+        outdir=outdirPath
+    )
     if(write_to_file){write_table(metrics$summary, out_path)}
 
     ############# Save plots  ##################################################

--- a/R/RWR_LOE.R
+++ b/R/RWR_LOE.R
@@ -167,7 +167,6 @@ save_plots_loe <- function(metrics, seed_geneset, query_geneset, outdir, modname
     p4 <- ggplot2::ggplot(metrics$results %>% dplyr::filter(InQueryGeneset==1)) + 
         ggplot2::geom_histogram(ggplot2::aes(x=rank), alpha=1, binwidth=100)
     
-    # out_path    <- get_file_path(seed_geneset$setid[1], query_geneset$setid[1], modname, outdir = outdir, ext = "metrics.png")
     out_path = get_file_path(
         "RWR-LOE",
         slug="metrics",

--- a/R/RWR_LOE.R
+++ b/R/RWR_LOE.R
@@ -167,7 +167,14 @@ save_plots_loe <- function(metrics, seed_geneset, query_geneset, outdir, modname
     p4 <- ggplot2::ggplot(metrics$results %>% dplyr::filter(InQueryGeneset==1)) + 
         ggplot2::geom_histogram(ggplot2::aes(x=rank), alpha=1, binwidth=100)
     
-    out_path    <- get_file_path(seed_geneset$setid[1], query_geneset$setid[1], modname, outdir = outdir, ext = "metrics.png")
+    # out_path    <- get_file_path(seed_geneset$setid[1], query_geneset$setid[1], modname, outdir = outdir, ext = "metrics.png")
+    out_path = get_file_path(
+        "RWR-LOE",
+        slug="metrics"
+        modname=modname,
+        outdir=outdir,
+        ext='.png'
+    )
     png(out_path, width = 1200, height=1000)
     
     grid::pushViewport(grid::viewport(layout = grid::grid.layout(2, 2)))
@@ -279,11 +286,17 @@ RWR_LOE <- function(data=NULL, seed_geneset=NULL, query_geneset=NULL, restart=0.
     print(head(results$RWRM_Results))
 
     # Define output path 
-    if(!is.null(query_geneset)) {
-        out_path = get_file_path("RWR-LOE", seed_geneset$setid[1],"vs", query_geneset$setid[1], modname, outdir=outdir, ext=".ranks.tsv")
-    } else {
-        out_path = get_file_path("RWR-LOE", seed_geneset$setid[1], modname, outdir=outdir, ext=".ranks.tsv")
-    }
+    # if(!is.null(query_geneset)) {
+    #     out_path = get_file_path("RWR-LOE", seed_geneset$setid[1],"vs", query_geneset$setid[1], modname, outdir=outdir, ext=".ranks.tsv")
+    # } else {
+    #     out_path = get_file_path("RWR-LOE", seed_geneset$setid[1], modname, outdir=outdir, ext=".ranks.tsv")
+    # }
+    out_path = get_file_path(
+        "RWR-LOE",
+        slug="ranks"
+        modname=modname,
+        outdir=outdir
+    )
     message(paste('Output path:', out_path))
 
     # Save the table of results, ie, scores and ranks for each gene in the network.
@@ -293,7 +306,13 @@ RWR_LOE <- function(data=NULL, seed_geneset=NULL, query_geneset=NULL, restart=0.
     if (!is.null(query_geneset) & eval) {
         message("evaluating metrics for finding query genes from seeds")
         metrics  <- calc_metrics_loe(results$RWRM_Results, seed_geneset, query_geneset)
-        out_path <- get_file_path(seed_geneset$setid[1], query_geneset$setid[1], modname, outdir=outdir, ext="metrics.tsv")
+        # out_path <- get_file_path(seed_geneset$setid[1], query_geneset$setid[1], modname, outdir=outdir, ext="metrics.tsv")
+        out_path = get_file_path(
+            "RWR-LOE",
+            slug="ranks"
+            modname=modname,
+            outdir=outdir
+        )
         write_table(metrics$summary, out_path)
         message(paste('Saved metrics summary to file:', out_path))
         save_plots_loe(metrics, seed_geneset, query_geneset, outdir, modname)

--- a/R/RWR_LOE.R
+++ b/R/RWR_LOE.R
@@ -170,7 +170,7 @@ save_plots_loe <- function(metrics, seed_geneset, query_geneset, outdir, modname
     # out_path    <- get_file_path(seed_geneset$setid[1], query_geneset$setid[1], modname, outdir = outdir, ext = "metrics.png")
     out_path = get_file_path(
         "RWR-LOE",
-        slug="metrics"
+        slug="metrics",
         modname=modname,
         outdir=outdir,
         ext='.png'
@@ -293,7 +293,7 @@ RWR_LOE <- function(data=NULL, seed_geneset=NULL, query_geneset=NULL, restart=0.
     # }
     out_path = get_file_path(
         "RWR-LOE",
-        slug="ranks"
+        slug="ranks",
         modname=modname,
         outdir=outdir
     )
@@ -309,7 +309,7 @@ RWR_LOE <- function(data=NULL, seed_geneset=NULL, query_geneset=NULL, restart=0.
         # out_path <- get_file_path(seed_geneset$setid[1], query_geneset$setid[1], modname, outdir=outdir, ext="metrics.tsv")
         out_path = get_file_path(
             "RWR-LOE",
-            slug="ranks"
+            slug="ranks",
             modname=modname,
             outdir=outdir
         )

--- a/R/RWR_netscore.R
+++ b/R/RWR_netscore.R
@@ -160,11 +160,6 @@ RWR_netscore <- function(
     }
     
     if (write_to_file) {
-        # out_path = get_file_path(
-        #      "NETSCORE_",
-        #      tools::file_path_sans_ext(basename(network)),
-        #      outdir=outdir
-        # )
         out_path = get_file_path(
             "NETSCORE",
             slug="scores",

--- a/R/RWR_netscore.R
+++ b/R/RWR_netscore.R
@@ -167,7 +167,7 @@ RWR_netscore <- function(
         # )
         out_path = get_file_path(
             "NETSCORE",
-            slug="scores"
+            slug="scores",
             modname=NULL,
             outdir=outdir
         )

--- a/R/RWR_netscore.R
+++ b/R/RWR_netscore.R
@@ -160,10 +160,16 @@ RWR_netscore <- function(
     }
     
     if (write_to_file) {
+        # out_path = get_file_path(
+        #      "NETSCORE_",
+        #      tools::file_path_sans_ext(basename(network)),
+        #      outdir=outdir
+        # )
         out_path = get_file_path(
-             "NETSCORE_",
-             tools::file_path_sans_ext(basename(network)),
-             outdir=outdir
+            "NETSCORE",
+            slug="scores"
+            modname=NULL,
+            outdir=outdir
         )
         write_table(out, out_path, verbose=verbose)
     }

--- a/R/RWR_shortestpaths.R
+++ b/R/RWR_shortestpaths.R
@@ -86,7 +86,7 @@ save_results = function(rwr_result, source_geneset=NULL, target_geneset=NULL, ou
         # }
         out_path = get_file_path(
             "RWR-SPATHS",
-            slug="edges"
+            slug="edges",
             modname=modname,
             outdir=outdir
         )

--- a/R/RWR_shortestpaths.R
+++ b/R/RWR_shortestpaths.R
@@ -79,11 +79,17 @@ save_results = function(rwr_result, source_geneset=NULL, target_geneset=NULL, ou
     } else if (!is.null(out_path)) {
         out_path = out_path
     } else {
-        if (is.null(target_geneset)) {
-            out_path = get_file_path("RWR-SPATHS_", source_geneset$setid[1], outdir=outdir)
-        } else {
-            out_path = get_file_path("RWR-SPATHS_", source_geneset$setid[1], target_geneset$setid[1], outdir=outdir)
-        }
+        # if (is.null(target_geneset)) {
+        #     out_path = get_file_path("RWR-SPATHS_", source_geneset$setid[1], outdir=outdir)
+        # } else {
+        #     out_path = get_file_path("RWR-SPATHS_", source_geneset$setid[1], target_geneset$setid[1], outdir=outdir)
+        # }
+        out_path = get_file_path(
+            "RWR-SPATHS",
+            slug="edges"
+            modname=modname,
+            outdir=outdir
+        )
     }
 
     # If out_path is still NULL, there's nothing to do.

--- a/R/RWR_shortestpaths.R
+++ b/R/RWR_shortestpaths.R
@@ -79,11 +79,6 @@ save_results = function(rwr_result, source_geneset=NULL, target_geneset=NULL, ou
     } else if (!is.null(out_path)) {
         out_path = out_path
     } else {
-        # if (is.null(target_geneset)) {
-        #     out_path = get_file_path("RWR-SPATHS_", source_geneset$setid[1], outdir=outdir)
-        # } else {
-        #     out_path = get_file_path("RWR-SPATHS_", source_geneset$setid[1], target_geneset$setid[1], outdir=outdir)
-        # }
         out_path = get_file_path(
             "RWR-SPATHS",
             slug="edges",

--- a/R/RWR_shortestpaths.R
+++ b/R/RWR_shortestpaths.R
@@ -87,7 +87,7 @@ save_results = function(rwr_result, source_geneset=NULL, target_geneset=NULL, ou
         out_path = get_file_path(
             "RWR-SPATHS",
             slug="edges",
-            modname=modname,
+            modname=NULL,
             outdir=outdir
         )
     }

--- a/R/utils.R
+++ b/R/utils.R
@@ -247,9 +247,25 @@ write_table = function(table, path, verbose=FALSE) {
     }
 }
 
-get_file_path = function(..., outdir=NULL, ext='.tsv') {
-    filename = paste(..., sep='_')
-    filename = substr(filename, 1, 99)
+# get_file_path = function(..., outdir=NULL, ext='.tsv') {
+#     filename = paste(..., sep='_')
+#     filename = substr(filename, 1, 99)
+#     filename = paste0(filename, ext)
+#     if (!is.null(outdir)) {
+#         filename = file.path(outdir, filename)
+#     }
+#     return(filename)
+# }
+
+get_file_path = function(script_name, slug=NULL, modname=NULL, outdir=NULL, ext='.tsv', sep='__') {
+    filename = script_name
+    if (!is.null(slug)) {
+        filename = paste(filename, slug, sep=sep)
+    }
+    if (!is.null(modname)) {
+        filename = paste(filename, modname, sep=sep)
+    }
+
     filename = paste0(filename, ext)
 
     if (!is.null(outdir)) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -247,16 +247,6 @@ write_table = function(table, path, verbose=FALSE) {
     }
 }
 
-# get_file_path = function(..., outdir=NULL, ext='.tsv') {
-#     filename = paste(..., sep='_')
-#     filename = substr(filename, 1, 99)
-#     filename = paste0(filename, ext)
-#     if (!is.null(outdir)) {
-#         filename = file.path(outdir, filename)
-#     }
-#     return(filename)
-# }
-
 get_file_path = function(script_name, slug=NULL, modname=NULL, outdir=NULL, ext='.tsv', sep='__') {
     filename = script_name
     if (!is.null(slug)) {

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -17,6 +17,7 @@ rwr_netscore="$PATH_TO_RWRtoolkit/inst/scripts/run_netscore.R"
 rwr_shortestpaths="$PATH_TO_RWRtoolkit/inst/scripts/run_shortestpaths.R"
 
 out_dir="$PATH_TO_RWRtoolkit/tmp"
+echo "out_dir=$out_dir"
 
 echo "Checking help ..."
 Rscript $rwr_make_multiplex -h > /dev/null
@@ -66,5 +67,8 @@ Rscript $rwr_shortestpaths \
     --outdir $out_dir \
     &> /dev/null
 echo "Done."
+
+echo "Outputs:"
+ls -lh $out_dir
 
 exit 0

--- a/tests/testthat/testRWR_LOE.R
+++ b/tests/testthat/testRWR_LOE.R
@@ -108,9 +108,23 @@ describe('RWR_LOE save_plots_loe', {
     test_query_geneset <- genesetB_3genes
     test_outdir <- "plots"
     test_modname <- "testmod"
-    expected_outputFileName <- RWRtoolkit::get_file_path(test_seed_geneset$setid[1], test_query_geneset$setid[1], test_modname, outdir=test_outdir, ext="metrics.png")
+    # expected_outputFileName <- RWRtoolkit::get_file_path(test_seed_geneset$setid[1], test_query_geneset$setid[1], test_modname, outdir=test_outdir, ext="metrics.png")
+
+    # The save_plots_loe fxn internally calls get_file_path, so we can use the
+    # same parameters to test the output file name.
+    expected_outputFileName <- RWRtoolkit::get_file_path(
+        "RWR-LOE",
+        slug="metrics"
+        modname=modname,
+        outdir=outdir,
+        ext='.png'
+    )
     
-    RWRtoolkit::save_plots_loe(metrics=test_metrics, seed_geneset=test_seed_geneset, query_geneset=test_query_geneset, outdir=test_outdir, modname=test_modname)
+    RWRtoolkit::save_plots_loe(metrics=test_metrics,
+                               seed_geneset=test_seed_geneset,
+                               query_geneset=test_query_geneset,
+                               outdir=test_outdir,
+                               modname=test_modname)
 
     expect_true(expected_outputFileName %in% list.files(recursive = TRUE))
     system(paste('rm -r plots'))

--- a/tests/testthat/testRWR_LOE.R
+++ b/tests/testthat/testRWR_LOE.R
@@ -106,17 +106,16 @@ describe('RWR_LOE save_plots_loe', {
     test_metrics <- generate_mock_metrics_list()
     test_seed_geneset <- genesetA_2genes
     test_query_geneset <- genesetB_3genes
-    test_outdir <- "plots"
     test_modname <- "testmod"
-    # expected_outputFileName <- RWRtoolkit::get_file_path(test_seed_geneset$setid[1], test_query_geneset$setid[1], test_modname, outdir=test_outdir, ext="metrics.png")
+    test_outdir <- "plots"
 
     # The save_plots_loe fxn internally calls get_file_path, so we can use the
     # same parameters to test the output file name.
     expected_outputFileName <- RWRtoolkit::get_file_path(
         "RWR-LOE",
         slug="metrics",
-        modname=modname,
-        outdir=outdir,
+        modname=test_modname,
+        outdir=test_outdir,
         ext='.png'
     )
     

--- a/tests/testthat/testRWR_LOE.R
+++ b/tests/testthat/testRWR_LOE.R
@@ -114,7 +114,7 @@ describe('RWR_LOE save_plots_loe', {
     # same parameters to test the output file name.
     expected_outputFileName <- RWRtoolkit::get_file_path(
         "RWR-LOE",
-        slug="metrics"
+        slug="metrics",
         modname=modname,
         outdir=outdir,
         ext='.png'

--- a/tests/testthat/testUtils.R
+++ b/tests/testthat/testUtils.R
@@ -253,6 +253,15 @@ describe('get_file_path', {
 
         expect_equal(outputFileName, expectedFileName)
     })
+    it('appends the slug to the base filename of the scriptname with default extension', {
+        baseFileName <- 'baseFile'
+        slugName <- 'slugName'
+
+        outputFileName <- RWRtoolkit::get_file_path(baseFileName, slugName)
+
+        expectedFileName <- paste(baseFileName, '__', slugName, '.tsv', sep='')
+        expect_equal(expectedFileName, outputFileName)
+    })
 })
 
 describe('dump_layers', {


### PR DESCRIPTION
# Description

Update the `get_file_path` function. Three arguments should be used to standardize the base filename for all outputs: `script_name`, `slug` (e.g., 'metrics'), and `modname` (from `--modname`). The `script_name` and `slug` together are sufficient to make sure that none of the RWR outputs will collide, and the `modname` (`--modname`) allows the user to provide a consistent label.