### PR TITLE
removed warning

### DIFF
--- a/R/RWR_shortestpaths.R
+++ b/R/RWR_shortestpaths.R
@@ -39,7 +39,7 @@ merge_networks = function(nw.mpo) {
     return(nw_merged)
 }
 
-get_shortest_paths = function(nw_merged, source_geneset, target_geneset, threads=NULL) {
+get_shortest_paths = function(nw_merged, source_geneset, target_geneset, threads=1) {
     # For each gene in source_geneset, get the shortest path to each gene in target_geneset.
     targets <- which(igraph::V(nw_merged)$name %in% target_geneset$gene)
     wt <- 1-igraph::E(nw_merged)$weightnorm


### PR DESCRIPTION
# Description :page_facing_up:

This is a fix for a test that was previously throwing warnings. 

In all other instances in which we use a parallel backend, there is a default number of threads as 1.  In this function we were using the default number of threads as null. That now is set to one. 


## New Features :gear:

N/A


## Fixed Bugs :bug:

```r
library(devtools)
devtools::test()
```
No longer throws warnings. 

## Additional Comments :pen:

N/A 